### PR TITLE
style: replace `h-screen` with `h-dvh`

### DIFF
--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -20,7 +20,7 @@ export default function Home() {
   if (error) return <ErrorPage />;
 
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-dvh p-8 pb-20 gap-16 sm:p-20">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
         <h1 className="text-2xl font-semibold">Logado</h1>
       </main>

--- a/apps/frontend/src/components/pages/AuthPage.tsx
+++ b/apps/frontend/src/components/pages/AuthPage.tsx
@@ -6,7 +6,7 @@ import { ProgressiveBlur } from "../ui/progressive-blur";
 
 export default function AuthPage() {
   return (
-    <main className="w-full h-screen flex">
+    <main className="w-full h-dvh flex">
       <div className="w-1/2 relative md:block hidden">
         <Image
           className="object-cover"

--- a/apps/frontend/src/components/pages/ErrorPage.tsx
+++ b/apps/frontend/src/components/pages/ErrorPage.tsx
@@ -1,6 +1,6 @@
 export default function ErrorPage() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-dvh p-8 pb-20 gap-16 sm:p-20">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
         <h1 className="text-2xl font-semibold">There was an error</h1>
       </main>

--- a/apps/frontend/src/components/pages/LoadingPage.tsx
+++ b/apps/frontend/src/components/pages/LoadingPage.tsx
@@ -1,6 +1,6 @@
 export default function LoadingPage() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-dvh p-8 pb-20 gap-16 sm:p-20">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
         <h1 className="text-2xl font-semibold">Loading...</h1>
       </main>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved page height responsiveness by updating layout styles to use dynamic viewport height units, enhancing display on mobile devices with dynamic browser UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->