### PR TITLE
fix: remove layout shift in the map by absolute positioning it

### DIFF
--- a/apps/frontend/src/app/(main)/map/page.tsx
+++ b/apps/frontend/src/app/(main)/map/page.tsx
@@ -16,11 +16,11 @@ export default function MapPage() {
   return (
     <Map
       initialViewState={{
-        zoom: 0,
-        longitude: -122.4,
-        latitude: 37.8,
+        zoom: 1.5,
+        longitude: 0,
+        latitude: 0,
       }}
-      style={{ width: "100%", height: "100vh" }}
+      style={{ width: "100vw", height: "100vh", position: "absolute" }}
       mapStyle={`https://api.maptiler.com/maps/streets/style.json?key=${process.env.NEXT_PUBLIC_MAPTILER_KEY}`}
     />
   );

--- a/apps/frontend/src/hooks/use-avatar.tsx
+++ b/apps/frontend/src/hooks/use-avatar.tsx
@@ -136,7 +136,7 @@ export function useAvatarMutations({
       if (context?.localUrl) {
         URL.revokeObjectURL(context.localUrl);
       }
-      // biome-ignore lint: shut up biome
+      // biome-ignore lint:
       if (fileInputRef && fileInputRef.current) {
         fileInputRef.current.value = "";
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the initial map view to display a broader area by adjusting the zoom level and center position.
  - Modified the map container to use the full viewport width and set its position to absolute for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->