### PR TITLE
fix: make image crop dialog responsive

### DIFF
--- a/apps/frontend/src/components/settings/SettingsDialog.tsx
+++ b/apps/frontend/src/components/settings/SettingsDialog.tsx
@@ -76,7 +76,7 @@ export function SettingsDialog({
             >
               <TabsTrigger
                 value="profile"
-                className="flex-col sm:flex-row items-center px-4 py-3 text-base"
+                className="flex-col sm:flex-row items-center px-4 py-3 text-lg md:text-base gap-3 md:gap-6"
               >
                 <HugeiconsIcon
                   icon={UserSquareIcon}
@@ -89,7 +89,7 @@ export function SettingsDialog({
               </TabsTrigger>
               <TabsTrigger
                 value="security"
-                className="flex-col sm:flex-row items-center px-4 py-3 text-base"
+                className="flex-col sm:flex-row items-center px-4 py-3 text-lg md:text-base gap-3 md:gap-6"
               >
                 <HugeiconsIcon
                   icon={LockKeyIcon}

--- a/apps/frontend/src/components/settings/avatar/ImageCropDialog.tsx
+++ b/apps/frontend/src/components/settings/avatar/ImageCropDialog.tsx
@@ -164,7 +164,7 @@ export default function ImageCropDialog({
         if (!open) onCropCancel();
       }}
     >
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md h-[100dvh] w-full md:w-fit md:h-fit">
         <DialogHeader>
           <DialogTitle>Crop your new avatar</DialogTitle>
         </DialogHeader>

--- a/apps/frontend/src/components/ui/input.tsx
+++ b/apps/frontend/src/components/ui/input.tsx
@@ -1,14 +1,58 @@
 import * as React from "react"
 import { cn } from "@/lib/utils"
+import { X } from "lucide-react";
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   iconLeft?: React.ReactNode
   iconRight?: React.ReactNode
   success?: boolean
+  showClear?: boolean 
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, iconLeft, iconRight, success = false, ...props }, ref) => {
+  ({ className, type, iconLeft, iconRight, success = false, showClear = true, ...props }, ref) => {
+    const [internalValue, setInternalValue] = React.useState(props.value || props.defaultValue || "");
+    const inputRef = React.useRef<HTMLInputElement>(null);
+    
+    const finalRef = ref || inputRef;
+
+    React.useEffect(() => {
+      if (props.value !== undefined) {
+        setInternalValue(props.value);
+      }
+    }, [props.value]);
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value;
+      setInternalValue(newValue);
+      if (props.onChange) {
+        props.onChange(e);
+      }
+    };
+
+    const handleClear = () => {
+      const input = (finalRef as React.RefObject<HTMLInputElement>)?.current;
+      if (input) {
+        const event = new Event('input', { bubbles: true });
+        Object.defineProperty(event, 'target', {
+          writable: false,
+          value: input
+        });
+        
+        input.value = '';
+        setInternalValue('');
+        
+        if (props.onChange) {
+          props.onChange(event as any);
+        }
+        
+        input.focus();
+      }
+    };
+
+    const hasValue = String(internalValue).length > 0;
+    const showClearIcon = showClear && hasValue;
+
     return (
       <div className="relative flex items-center w-full max-w-[32rem]">
         {iconLeft && (
@@ -21,7 +65,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         )}
         <input
           type={type}
-          ref={ref}
+          ref={finalRef}
           data-slot="input"
           className={cn(
             "file:text-foreground max-w-[32rem] placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 flex h-15 w-full min-w-0 rounded-xl border-0 bg-muted px-3 py-1 text-sm md:text-lg shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
@@ -29,11 +73,28 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
             success && "bg-success-foreground ring-success ring-3 transition-all focus-visible:ring-success ",
             iconLeft && "pl-12",
-            iconRight && "pr-12",
+            (iconRight || showClearIcon) && "pr-12",
+            iconRight && showClearIcon && "pr-20", 
             className
           )}
           {...props}
+          onChange={handleInputChange}
         />
+        
+        {showClearIcon && (
+          <button
+            type="button"
+            onClick={handleClear}
+            className={cn(
+              "absolute flex items-center justify-center w-6 h-6 text-muted-foreground hover:text-foreground transition-colors cursor-pointer rounded-sm hover:bg-muted-foreground/10",
+              iconRight ? "right-12" : "right-3"
+            )}
+            tabIndex={-1}
+          >
+            <X size={26} />
+          </button>
+        )}
+        
         {iconRight && (
           <div className="absolute right-3 flex items-center text-muted-foreground">
             {iconRight}

--- a/apps/frontend/src/components/ui/input.tsx
+++ b/apps/frontend/src/components/ui/input.tsx
@@ -89,7 +89,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
               "absolute flex items-center justify-center w-6 h-6 text-muted-foreground hover:text-foreground transition-colors cursor-pointer rounded-sm hover:bg-muted-foreground/10",
               iconRight ? "right-12" : "right-3"
             )}
-            tabIndex={-1}
+            tabIndex={0}
+            aria-label="Clear input"
           >
             <X size={26} />
           </button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the responsiveness of the avatar image crop dialog, ensuring it displays optimally across different screen sizes.
  - Enhanced the layout and spacing of profile and security tab triggers for better readability on various screen sizes.
- **New Features**
  - Added an optional clear button to input fields, allowing users to quickly clear entered text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->