### PR TITLE
fix: remove clear option from profile fields

### DIFF
--- a/apps/frontend/src/components/settings/ProfileTab.tsx
+++ b/apps/frontend/src/components/settings/ProfileTab.tsx
@@ -89,6 +89,7 @@ export default function ProfileTab({ user, error }: ProfileTabProps) {
                   name="name"
                   type="text"
                   autoComplete="name"
+                  showClear={false}
                   defaultValue={user?.name || "N/A"}
                   success={success}
                   onChange={(e) =>
@@ -115,6 +116,7 @@ export default function ProfileTab({ user, error }: ProfileTabProps) {
                 name="email"
                 type="email"
                 autoComplete="email"
+                showClear={false}
                 defaultValue={user?.email || "N/A"}
                 className=" text-foreground/80 p-2 max-w-64 ml-auto text-base"
                 disabled


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed the clear button from the name and email input fields in the profile settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->