### PR TITLE
style: adjust dialog style on mobile

### DIFF
--- a/apps/frontend/src/components/trips/TripCreationDialog.tsx
+++ b/apps/frontend/src/components/trips/TripCreationDialog.tsx
@@ -170,7 +170,7 @@ export function TripCreationDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={handleDialogChange}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="sm:max-w-md sm:h-auto max-w-none w-full h-full min-w-full">
           <DialogHeader>
             <DialogTitle>{getTitle()}</DialogTitle>
           </DialogHeader>

--- a/apps/frontend/src/components/trips/TripCreationDialog.tsx
+++ b/apps/frontend/src/components/trips/TripCreationDialog.tsx
@@ -170,7 +170,6 @@ export function TripCreationDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={handleDialogChange}>
-        +{' '}
         <DialogContent className="sm:max-w-md sm:h-auto max-w-none w-full h-dvh max-h-dvh overflow-y-auto rounded-none p-0 sm:rounded-lg sm:p-6">
           <DialogHeader>
             <DialogTitle>{getTitle()}</DialogTitle>

--- a/apps/frontend/src/components/trips/TripCreationDialog.tsx
+++ b/apps/frontend/src/components/trips/TripCreationDialog.tsx
@@ -170,7 +170,8 @@ export function TripCreationDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={handleDialogChange}>
-        <DialogContent className="sm:max-w-md sm:h-auto max-w-none w-full h-full min-w-full">
+        +{' '}
+        <DialogContent className="sm:max-w-md sm:h-auto max-w-none w-full h-dvh max-h-dvh overflow-y-auto rounded-none p-0 sm:rounded-lg sm:p-6">
           <DialogHeader>
             <DialogTitle>{getTitle()}</DialogTitle>
           </DialogHeader>

--- a/apps/frontend/src/components/trips/form/steps/Details.tsx
+++ b/apps/frontend/src/components/trips/form/steps/Details.tsx
@@ -39,7 +39,7 @@ export default function Details() {
 
   return (
     <div className="flex flex-col md:flex-row mx-6 md:mx-10 gap-8 h-[95%] py-2">
-      <div className="flex flex-col w-full md:w-[40%] gap-4 h-full min-h-0 overflow-y-auto p-1">
+      <div className="flex flex-col w-full md:w-[40%] gap-4 h-full md:min-h-0 md:overflow-y-auto p-1">
         <div className="flex flex-col gap-1 px-1 flex-shrink-0">
           <Label className="text-base">Title</Label>
           <Input
@@ -78,9 +78,10 @@ export default function Details() {
           </div>
         </div>
       </div>
-      <div className="flex flex-col w-full md:w-[60%] gap-1 h-full">
+
+      <div className="flex flex-col w-full md:w-[60%] gap-1 md:h-full">
         <Label className="text-base flex-shrink-0">Memories</Label>
-        <div className="flex-1 min-h-0">
+        <div className="md:flex-1 md:min-h-0 min-h-[400px]">
           <FileInput
             files={images}
             onFilesChange={actions.setImages}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Trip Creation dialog now uses the full available width and height, removing previous size limits for a more immersive layout.
  * Dialog content supports internal vertical scrolling; padding and corner styling are compact on small screens and padded/rounded on larger screens.
  * Trip details layout: column height and scrolling behaviors are now responsive (applied at medium+ breakpoints), and the memories input area gains a minimum height on small viewports.
  * No changes to behavior, data, or interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->